### PR TITLE
Improve fun facts fallback handling

### DIFF
--- a/src/components/funFacts/FlipCard.jsx
+++ b/src/components/funFacts/FlipCard.jsx
@@ -11,7 +11,8 @@ const FlipCard = ({ person }) => {
 
   // State for flipped status and fact
   const [isFlipped, setIsFlipped] = useState(false);
-  const [fact, setFact] = useState(person.fact);
+  const fallbackFact = person?.fallbackFact ?? 'Fun fact coming soon!';
+  const [fact, setFact] = useState(person?.fact ?? fallbackFact);
 
   // Animation controls
   const controls = useAnimation();
@@ -32,16 +33,27 @@ const FlipCard = ({ person }) => {
   // Fetch a new fact for the specified person
   const fetchNewFact = async (personName) => {
     try {
-      const response = await axios.get(`https://rest.blackhistoryapi.io/fact?people=${personName}`, {
-        headers: { 'X-Api-Key': 'amVtU3VuIEphbiAxNCAyMDI0IDExOj' },
-      });
+      const response = await axios.get(
+        `https://rest.blackhistoryapi.io/fact?people=${encodeURIComponent(personName)}`,
+        {
+          headers: { 'X-Api-Key': 'amVtU3VuIEphbiAxNCAyMDI0IDExOj' },
+        }
+      );
 
-      const facts = response.data.Results;
-      const selectedFact = facts[Math.floor(Math.random() * facts.length)];
-      return selectedFact.text;
+      const facts = response?.data?.Results ?? [];
+
+      if (Array.isArray(facts) && facts.length > 0) {
+        const selectedFact = facts[Math.floor(Math.random() * facts.length)];
+
+        if (selectedFact?.text) {
+          return selectedFact.text;
+        }
+      }
+
+      return fallbackFact;
     } catch (error) {
       console.error(`Error fetching new fact for ${personName}`, error);
-      return 'Error fetching data';
+      return fallbackFact;
     }
   };
 

--- a/src/components/funFacts/FlipDeck.jsx
+++ b/src/components/funFacts/FlipDeck.jsx
@@ -1,67 +1,112 @@
 // FlipDeck.jsx
-import React, { useState, useEffect } from 'react';
+import React, { useEffect, useState } from 'react';
 import axios from 'axios';
 import FlipCard from './FlipCard';
-import historicalPeopleData from './historicalPeopleData'; // Updated import
+import defaultPeopleData from './historicalPeopleData';
 
-const FlipDeck = () => {
-  // State for person facts and loading status
+const buildFallbackPerson = (person) => {
+  const {
+    name,
+    imageFileName,
+    fallbackFact = 'Fun fact coming soon!',
+    fallbackTags = [],
+    fallbackSource = '',
+  } = person;
+
+  const imagePath = `/images/${imageFileName}`;
+
+  return {
+    name,
+    imagePath,
+    fact: fallbackFact,
+    tags: fallbackTags,
+    source: fallbackSource,
+    fallbackFact,
+    fallbackTags,
+    fallbackSource,
+  };
+};
+
+const FlipDeck = ({ historicalPeopleData: peopleData = defaultPeopleData }) => {
   const [personFacts, setPersonFacts] = useState([]);
   const [loading, setLoading] = useState(true);
 
-  // Fetch person facts on component mount
   useEffect(() => {
+    let isMounted = true;
+    const normalizedPeople = Array.isArray(peopleData) ? peopleData : [];
+
     const fetchPersonFacts = async () => {
-      // Extract names and image file names from historicalPeopleData
-      const people = historicalPeopleData.map((person) => person.name);
-
-      // Fetch person facts for each person in historicalPeopleData
-      const fetchDataPromises = historicalPeopleData.map(async ({ name, imageFileName }) => {
-        try {
-          const response = await axios.get(`https://rest.blackhistoryapi.io/fact?people=${name}`, {
-            headers: { 'X-Api-Key': 'amVtU3VuIEphbiAxNCAyMDI0IDExOj' },
-          });
-
-          // Select a random fact for the person
-          const facts = response.data.Results;
-          const selectedFact = facts[Math.floor(Math.random() * facts.length)];
-
-          // Return an object with person details and the selected fact
-          return { name: name, imagePath: "/images/" + imageFileName, fact: selectedFact.text, tags: selectedFact.tags };
-        } catch (error) {
-          // Handle errors in fetching person facts
-          console.error(`Error fetching person facts for ${name}`, error);
-          return { name: name, fact: 'Error fetching data', tags: [] };
-        }
-      });
-
       try {
-        // Wait for all fetches to complete and set person facts
-        const factResults = await Promise.all(fetchDataPromises);
-        setPersonFacts(factResults);
-        setLoading(false);
+        const factResults = await Promise.all(
+          normalizedPeople.map(async (person) => {
+            const fallback = buildFallbackPerson(person);
+
+            try {
+              const response = await axios.get(
+                `https://rest.blackhistoryapi.io/fact?people=${encodeURIComponent(person.name)}`,
+                {
+                  headers: { 'X-Api-Key': 'amVtU3VuIEphbiAxNCAyMDI0IDExOj' },
+                }
+              );
+
+              const facts = response?.data?.Results ?? [];
+
+              if (Array.isArray(facts) && facts.length > 0) {
+                const selectedFact = facts[Math.floor(Math.random() * facts.length)];
+
+                return {
+                  ...fallback,
+                  fact: selectedFact?.text ?? fallback.fact,
+                  tags: Array.isArray(selectedFact?.tags)
+                    ? selectedFact.tags
+                    : fallback.tags,
+                  source: selectedFact?.source ?? fallback.source,
+                };
+              }
+
+              return fallback;
+            } catch (error) {
+              console.error(`Error fetching person facts for ${person.name}`, error);
+              return fallback;
+            }
+          })
+        );
+
+        if (isMounted) {
+          setPersonFacts(factResults);
+          setLoading(false);
+        }
       } catch (error) {
-        // Handle errors in the overall fetching process
         console.error('Error fetching person facts', error);
-        setLoading(false);
+
+        if (isMounted) {
+          setPersonFacts(normalizedPeople.map((person) => buildFallbackPerson(person)));
+          setLoading(false);
+        }
       }
     };
 
-    // Invoke the fetch function
-    fetchPersonFacts();
-  }, []);
+    if (normalizedPeople.length > 0) {
+      fetchPersonFacts();
+    } else {
+      setPersonFacts([]);
+      setLoading(false);
+    }
 
-  // Render loading message while fetching data
+    return () => {
+      isMounted = false;
+    };
+  }, [peopleData]);
+
   if (loading) {
     return <p>Loading...</p>;
   }
 
-  // Render the grid with FlipCards for each person
   return (
     <div className="grid-container">
       <div className="card-container">
-        {personFacts.map((person, index) => (
-          <FlipCard key={index} person={person} />
+        {personFacts.map((person) => (
+          <FlipCard key={person.name} person={person} />
         ))}
       </div>
     </div>

--- a/src/components/funFacts/RandomFactCarousel.jsx
+++ b/src/components/funFacts/RandomFactCarousel.jsx
@@ -1,64 +1,98 @@
 // RandomFactCarousel.jsx
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import axios from 'axios';
 import '../funFacts/randomFactCarousel.css';
+import historicalPeopleData from './historicalPeopleData';
+
+const FALLBACK_FACTS = historicalPeopleData.map(
+  ({ name, fallbackFact = 'Fun fact coming soon!', fallbackTags = [], fallbackSource = '' }) => ({
+    text: fallbackFact,
+    people: [name],
+    tags: fallbackTags,
+    source: fallbackSource,
+  })
+);
 
 const RandomFactCarousel = () => {
-  // State to store fetched facts and the current fact index
-  const [facts, setFacts] = useState([]);
-  const [currentFactIndex, setCurrentFactIndex] = useState(0);
-  
-  // Ref to track component mount
+  const [facts, setFacts] = useState(FALLBACK_FACTS);
+  const [currentFactIndex, setCurrentFactIndex] = useState(() =>
+    Math.floor(Math.random() * FALLBACK_FACTS.length)
+  );
+  const [isUsingFallback, setIsUsingFallback] = useState(true);
   const isMounted = useRef(false);
 
-  // Function to fetch random facts from the API
-  const getRandomFacts = async () => {
+  const setFallbackFacts = useCallback(() => {
+    const randomIndex = Math.floor(Math.random() * FALLBACK_FACTS.length);
+    setFacts(FALLBACK_FACTS);
+    setCurrentFactIndex(randomIndex);
+    setIsUsingFallback(true);
+  }, []);
+
+  const getRandomFacts = useCallback(async () => {
     try {
-      // Fetch random facts from the API
       const response = await axios.get('https://rest.blackhistoryapi.io/fact/random', {
         headers: { 'X-Api-Key': 'amVtU3VuIEphbiAxNCAyMDI0IDExOj' },
         params: { limit: 5 },
       });
 
-      const data = response.data.Results;
+      const data = Array.isArray(response?.data?.Results) ? response.data.Results : [];
 
-      // Update state with fetched facts
-      if (data) {
+      if (data.length > 0) {
         setFacts(data);
         setCurrentFactIndex(0);
+        setIsUsingFallback(false);
       } else {
-        setFacts([
-          {
-            text: 'No information available.',
-            people: [''],
-            tags: [],
-          },
-        ]);
+        setFallbackFacts();
       }
     } catch (error) {
-      // Handle errors in fetching random facts
-      setFacts([
-        {
-          text: 'Failed to fetch random facts.',
-          people: [''],
-          tags: [],
-        },
-      ]);
+      console.error('Error fetching random facts', error);
+      setFallbackFacts();
     }
-  };
+  }, [setFallbackFacts]);
 
   useEffect(() => {
-    // Fetch random facts on component mount
     if (!isMounted.current) {
       getRandomFacts();
       isMounted.current = true;
     }
-  }, []); // Empty dependency array to only fetch on mount
+  }, [getRandomFacts]); // Empty dependency array to only fetch on mount
 
-  // Function to handle refreshing and fetching new random facts
+  useEffect(() => {
+    if (!isUsingFallback) {
+      return undefined;
+    }
+
+    const retryTimeout = setTimeout(() => {
+      getRandomFacts();
+    }, 60000);
+
+    return () => clearTimeout(retryTimeout);
+  }, [getRandomFacts, isUsingFallback]);
+
   const handleRefresh = () => {
-    getRandomFacts();
+    if (isUsingFallback) {
+      setFallbackFacts();
+      return;
+    }
+
+    if (facts.length <= 1) {
+      getRandomFacts();
+      return;
+    }
+
+    setCurrentFactIndex((prevIndex) => {
+      const nextIndex = (prevIndex + 1) % facts.length;
+
+      if (nextIndex === 0) {
+        getRandomFacts();
+      }
+
+      return nextIndex;
+    });
   };
+
+  const currentFact = facts[currentFactIndex] ?? FALLBACK_FACTS[0];
+  const hasSource = Boolean(currentFact?.source);
 
   return (
     <div className="hero-section bg-gradient-to-r from-green-800 via-green-600 to-green-400 bg-cover bg-center h-3/4 md:h-2/3 lg:h-1/2 flex items-center justify-center relative text-white mb-8">
@@ -70,17 +104,26 @@ const RandomFactCarousel = () => {
           Did You Know?
         </h2>
         <div className="fact-card p-8 bg-green-950 rounded-md shadow-lg text-gray-300">
-          <h3 className="text-xl md:text-2xl mb-4">{facts[currentFactIndex]?.people?.[0]}</h3>
-          <p className="text-sm md:text-base mb-2">{facts[currentFactIndex]?.tags?.join(', ')}</p>
-          <p className="text-lg md:text-xl mb-4">{facts[currentFactIndex]?.text}</p>
-          <a
-            href={facts[currentFactIndex]?.source}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-red-400 hover:text-blue-200 underline"
-          >
-            Learn More
-          </a>
+          <h3 className="text-xl md:text-2xl mb-4">{currentFact?.people?.[0]}</h3>
+          <p className="text-sm md:text-base mb-2">{currentFact?.tags?.join(', ')}</p>
+          <p className="text-lg md:text-xl mb-4">{currentFact?.text}</p>
+          {hasSource ? (
+            <a
+              href={currentFact.source}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-red-400 hover:text-blue-200 underline"
+            >
+              Learn More
+            </a>
+          ) : (
+            <span className="text-sm md:text-base text-yellow-200">Source unavailable</span>
+          )}
+          {isUsingFallback && (
+            <p className="text-xs md:text-sm text-yellow-300 mt-4">
+              Showing curated facts while we reconnect to the live feed.
+            </p>
+          )}
         </div>
         <button
           className="refresh-button bg-yellow-400 hover:bg-green-400 text-white px-4 py-2 mt-4 mb-8 rounded-full hover:bg-blue-600 transition duration-300"

--- a/src/components/funFacts/historicalPeopleData.jsx
+++ b/src/components/funFacts/historicalPeopleData.jsx
@@ -1,22 +1,133 @@
 // historicalPeopleData.jsx
 
 const historicalPeopleData = [
-  { id: 1, name: 'Barack Obama', imageFileName: 'barack-obama-1129156_640.jpg' },
-  { id: 2, name: 'Rube Foster', imageFileName: 'RubeFoster.png' },
-  { id: 3, name: 'Bob Marley', imageFileName: 'BobMarley.png' },
-  { id: 4, name: 'Lauryn Hill', imageFileName: 'LaurynHill.png' },
-  { id: 5, name: 'Stevie Wonder', imageFileName: 'StevieWonder.png' },
-  { id: 6, name: 'Angela Davis', imageFileName: 'AngelaDavis.png' },
-  { id: 7, name: 'Claudette Colvin', imageFileName: 'ClaudetteColvin.png' },
-  { id: 8, name: 'Bessie Coleman', imageFileName: 'BessieColeman.png' },
-  { id: 9, name: 'Carter G. Woodson', imageFileName: 'CarterGWoodson.png' },
-  { id: 10, name: 'Shirley Chisholm', imageFileName: 'ShirleyChisholm.png' },
-  { id: 11, name: 'Alice Walker', imageFileName: 'AliceWalker.png' },
-  { id: 12, name: 'John Lewis', imageFileName: 'JohnRobertLewis.png' },
-  { id: 13, name: 'Benjamin Banneker', imageFileName: 'BenjaminBanneker.png' },
-  { id: 14, name: 'Nelson Rolihlahla Mandela', imageFileName: 'NelsonMandela.png' },
+  {
+    id: 1,
+    name: 'Barack Obama',
+    imageFileName: 'barack-obama-1129156_640.jpg',
+    fallbackFact:
+      'Barack Obama became the 44th President of the United States in 2009, becoming the first African American to hold the office.',
+    fallbackTags: ['Politics', 'Leadership'],
+    fallbackSource: 'https://www.whitehouse.gov/about-the-white-house/presidents/barack-obama/',
+  },
+  {
+    id: 2,
+    name: 'Rube Foster',
+    imageFileName: 'RubeFoster.png',
+    fallbackFact:
+      'Rube Foster founded the Negro National League in 1920, creating the first successful professional league for Black baseball teams.',
+    fallbackTags: ['Sports', 'Baseball'],
+    fallbackSource: 'https://baseballhall.org/hall-of-famers/foster-rube',
+  },
+  {
+    id: 3,
+    name: 'Bob Marley',
+    imageFileName: 'BobMarley.png',
+    fallbackFact:
+      "Bob Marley's music helped popularize reggae worldwide, and his album 'Exodus' was named Album of the Century by Time Magazine in 1999.",
+    fallbackTags: ['Music', 'Culture'],
+    fallbackSource: 'https://www.britannica.com/biography/Bob-Marley',
+  },
+  {
+    id: 4,
+    name: 'Lauryn Hill',
+    imageFileName: 'LaurynHill.png',
+    fallbackFact:
+      "Lauryn Hill's debut solo album 'The Miseducation of Lauryn Hill' won five Grammy Awards in 1999, including Album of the Year.",
+    fallbackTags: ['Music', 'Awards'],
+    fallbackSource: 'https://www.britannica.com/biography/Lauryn-Hill',
+  },
+  {
+    id: 5,
+    name: 'Stevie Wonder',
+    imageFileName: 'StevieWonder.png',
+    fallbackFact:
+      "Stevie Wonder earned his first No. 1 hit, 'Fingertips Pt. 2,' at age 13, launching one of the most successful careers in popular music.",
+    fallbackTags: ['Music', 'Inspiration'],
+    fallbackSource: 'https://www.britannica.com/biography/Stevie-Wonder',
+  },
+  {
+    id: 6,
+    name: 'Angela Davis',
+    imageFileName: 'AngelaDavis.png',
+    fallbackFact:
+      'Angela Davis is a scholar and activist whose work on racial, gender, and economic justice has influenced movements worldwide since the 1960s.',
+    fallbackTags: ['Activism', 'Education'],
+    fallbackSource: 'https://www.britannica.com/biography/Angela-Davis',
+  },
+  {
+    id: 7,
+    name: 'Claudette Colvin',
+    imageFileName: 'ClaudetteColvin.png',
+    fallbackFact:
+      'At just 15, Claudette Colvin refused to give up her seat on a segregated Montgomery bus in March 1955, nine months before Rosa Parks.',
+    fallbackTags: ['Civil Rights', 'Youth Activism'],
+    fallbackSource: 'https://www.britannica.com/biography/Claudette-Colvin',
+  },
+  {
+    id: 8,
+    name: 'Bessie Coleman',
+    imageFileName: 'BessieColeman.png',
+    fallbackFact:
+      "Bessie Coleman earned her pilot's license in France in 1921, becoming the first African American and Native American woman aviator.",
+    fallbackTags: ['Aviation', 'Trailblazer'],
+    fallbackSource: 'https://www.britannica.com/biography/Bessie-Coleman',
+  },
+  {
+    id: 9,
+    name: 'Carter G. Woodson',
+    imageFileName: 'CarterGWoodson.png',
+    fallbackFact:
+      'Carter G. Woodson launched Negro History Week in 1926, which grew into the annual celebration now known as Black History Month.',
+    fallbackTags: ['History', 'Education'],
+    fallbackSource: 'https://www.britannica.com/biography/Carter-G-Woodson',
+  },
+  {
+    id: 10,
+    name: 'Shirley Chisholm',
+    imageFileName: 'ShirleyChisholm.png',
+    fallbackFact:
+      'Shirley Chisholm became the first Black woman elected to the U.S. Congress in 1968 and later ran for president in 1972.',
+    fallbackTags: ['Politics', 'Trailblazer'],
+    fallbackSource: 'https://www.britannica.com/biography/Shirley-Chisholm',
+  },
+  {
+    id: 11,
+    name: 'Alice Walker',
+    imageFileName: 'AliceWalker.png',
+    fallbackFact:
+      "Alice Walker wrote the novel 'The Color Purple,' which won both the Pulitzer Prize and the National Book Award in 1983.",
+    fallbackTags: ['Literature', 'Awards'],
+    fallbackSource: 'https://www.britannica.com/biography/Alice-Walker',
+  },
+  {
+    id: 12,
+    name: 'John Lewis',
+    imageFileName: 'JohnRobertLewis.png',
+    fallbackFact:
+      'John Lewis helped lead the 1965 Selma to Montgomery marches and later served more than 30 years in the U.S. House of Representatives.',
+    fallbackTags: ['Civil Rights', 'Leadership'],
+    fallbackSource: 'https://www.britannica.com/biography/John-Lewis',
+  },
+  {
+    id: 13,
+    name: 'Benjamin Banneker',
+    imageFileName: 'BenjaminBanneker.png',
+    fallbackFact:
+      'Benjamin Banneker was a self-taught mathematician who published a respected almanac and assisted in surveying Washington, D.C., in the 1790s.',
+    fallbackTags: ['Science', 'Innovation'],
+    fallbackSource: 'https://www.britannica.com/biography/Benjamin-Banneker',
+  },
+  {
+    id: 14,
+    name: 'Nelson Rolihlahla Mandela',
+    imageFileName: 'NelsonMandela.png',
+    fallbackFact:
+      "After spending 27 years imprisoned for opposing apartheid, Nelson Mandela became South Africa's first Black president in 1994.",
+    fallbackTags: ['Leadership', 'Freedom'],
+    fallbackSource: 'https://www.britannica.com/biography/Nelson-Mandela',
+  },
 ];
-
 
 export default historicalPeopleData;
 


### PR DESCRIPTION
## Summary
- add curated fallback facts, tags, and sources for each featured historical figure
- update the flip deck to keep portraits visible and rely on the new fallback data whenever API calls fail
- refresh the random fact carousel to reuse fallback content, show an offline notice, and retry the live feed periodically

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68c95e3d6e2c83258bd9ecacaa5fb664